### PR TITLE
[FEAT] 회원가입 데이터 JSON으로 저장

### DIFF
--- a/components/auth-form-element.js
+++ b/components/auth-form-element.js
@@ -1,4 +1,5 @@
 import handleNavigation from '../utils/navigation.js'
+import saveDataInJson from '../utils/save-data-in-json.js'
 
 class AuthFormElement extends HTMLElement {
   constructor() {
@@ -101,6 +102,16 @@ class AuthFormElement extends HTMLElement {
         if (this.validateForm() === 'posts') {
           handleNavigation('/html/Posts.html')
         } else if (this.validateForm() === 'login') {
+          const email = this.shadowRoot
+            .getElementById('input-email')
+            .value.trim()
+          const password = this.shadowRoot
+            .getElementById('input-password')
+            .value.trim()
+          const nickname = this.shadowRoot
+            .getElementById('input-nickname')
+            .value.trim()
+          saveDataInJson('user', email, password, nickname)
           handleNavigation('/html/Log-in.html')
         }
       })

--- a/utils/save-data-in-json.js
+++ b/utils/save-data-in-json.js
@@ -1,0 +1,34 @@
+export default function saveDataInLocalStorage(
+  type,
+  email,
+  password,
+  nickname,
+) {
+  const data = {
+    user_email: email,
+    user_pw: password,
+    user_name: nickname,
+  }
+
+  if (type === 'user') {
+    localStorage.setItem('user', JSON.stringify(data))
+  } else if (type === 'post') {
+    const post = {
+      post_title: memoTitle,
+      post_writer: memoContent,
+      post_updatedAt: '',
+      post_contents: '',
+      post_likes: '',
+      post_views: '',
+      post_comments: '',
+    }
+    localStorage.setItem('post', JSON.stringify(post))
+  } else if (type === 'comment') {
+    const comment = {
+      comment_writer: memoTitle,
+      comment_updatedAt: memoContent,
+      comment_contents: '',
+    }
+    localStorage.setItem('comment', JSON.stringify(comment))
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

> 로컬 스토리지에 회원가입 데이터를 JSON 형태로 저장합니다.

### 스크린샷

> ![image](https://github.com/user-attachments/assets/c6110817-14a6-4b43-ba34-6e39252bfd57)

## 💬리뷰 요구사항