### PR TITLE
[FIX] make-post 페이지 접근시 로그인 여부 확인 후 접근 허용 또는 로그인 페이지로 라우팅

### DIFF
--- a/components/post-form.element.js
+++ b/components/post-form.element.js
@@ -14,6 +14,13 @@ class postFormElement extends HTMLElement {
   }
 
   async connectedCallback() {
+    const isLogin = JSON.parse(localStorage.getItem('isLogin')) || false
+    if (!isLogin) {
+      alert('로그인 후 작성할 수 있습니다.')
+      handleNavigation('/html/Log-in.html')
+
+      return
+    }
     this.checkLocation()
     if (!this.isMakePostPage) {
       await this.loadPostData()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 

## 📝작업 내용

```javascript 
async connectedCallback() {
    const isLogin = JSON.parse(localStorage.getItem('isLogin')) || false
    if (!isLogin) {
      alert('로그인 후 작성할 수 있습니다.')
      handleNavigation('/html/Log-in.html')

      return
    }
    this.checkLocation()
    if (!this.isMakePostPage) {
      await this.loadPostData()
    }
    this.shadowRoot.innerHTML = this.template()
    this.addEventListener()
  } 
```

### 스크린샷

> ![무제](https://github.com/user-attachments/assets/8ed8327f-57d1-4314-985a-07923794d319)

