### PR TITLE
[FIX] 로그인 상태에 따라 게시글 수정, 삭제 접근 제한

### DIFF
--- a/components/post-element.js
+++ b/components/post-element.js
@@ -6,6 +6,8 @@ class PostElement extends HTMLElement {
   constructor() {
     super()
     this.attachShadow({ mode: 'open' })
+    this.storedData = JSON.parse(localStorage.getItem('user'))
+    this.isLogin = JSON.parse(localStorage.getItem('isLogin')) || false
     this.post = null
     this.postId = null
     this.isLiked = false
@@ -31,9 +33,8 @@ class PostElement extends HTMLElement {
   }
 
   async updateLikes() {
-    const isLogin = JSON.parse(localStorage.getItem('isLogin')) || false
-    if (!isLogin) {
-      alert('로그인 후 좋아요를 누를 수 있습니다.')
+    if (!this.isLogin) {
+      alert('로그인 후 이용할 수 있습니다.')
       return
     }
 
@@ -135,8 +136,23 @@ class PostElement extends HTMLElement {
     const updatePost = this.shadowRoot.getElementById('button-update')
     const likes = this.shadowRoot.getElementById('post-interaction-likes')
 
-    deletePost?.addEventListener('click', () => this.openModal())
-    updatePost?.addEventListener('click', () => this.navigateToEditPage())
+    deletePost?.addEventListener('click', () => {
+      if (!this.isLogin || this.storedData.email !== this.post.post_writer) {
+        alert('게시글 작성자만 이용할 수 있는 기능입니다.')
+        return
+      } else {
+        this.openModal()
+      }
+    })
+    updatePost?.addEventListener('click', () => {
+      if (!this.isLogin || this.storedData.email !== this.post.post_writer) {
+        alert('게시글 작성자만 이용할 수 있는 기능입니다.')
+        return
+      } else {
+        this.openModal()
+      }
+      this.navigateToEditPage()
+    })
     likes?.addEventListener('click', async () => this.updateLikes())
   }
 

--- a/components/post-element.js
+++ b/components/post-element.js
@@ -137,7 +137,7 @@ class PostElement extends HTMLElement {
     const likes = this.shadowRoot.getElementById('post-interaction-likes')
 
     deletePost?.addEventListener('click', () => {
-      if (!this.isLogin || this.storedData.email !== this.post.post_writer) {
+      if (!this.isLogin || this.storedData.nickname !== this.post.post_writer) {
         alert('게시글 작성자만 이용할 수 있는 기능입니다.')
         return
       } else {
@@ -145,7 +145,7 @@ class PostElement extends HTMLElement {
       }
     })
     updatePost?.addEventListener('click', () => {
-      if (!this.isLogin || this.storedData.email !== this.post.post_writer) {
+      if (!this.isLogin || this.storedData.nickname !== this.post.post_writer) {
         alert('게시글 작성자만 이용할 수 있는 기능입니다.')
         return
       } else {

--- a/components/post-element.js
+++ b/components/post-element.js
@@ -186,6 +186,7 @@ class PostElement extends HTMLElement {
 
   async deleteContirm() {
     deletePost(this.postId)
+    alert('게시글이 삭제되었습니다.')
     handleNavigation('/html/Posts.html')
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 

## 📝작업 내용

> 로그인 상태에 따라 게시글 수정, 삭제에 대한 접근을 제한합니다.
> 기능별 alert 메세지를 분리합니다.

### 스크린샷 

> | 로그인 하지 않은 경우 | 로그인 하였으나 인가되지 않은 경우 | 인가된 접근의 경우 |
> | -- | -- | -- |
> | ![무제](https://github.com/user-attachments/assets/cbcca864-557f-4b97-92cf-be39c7611777) | ![무제](https://github.com/user-attachments/assets/0e4f6d52-67a2-47db-9e39-3e5e46cedd57) | ![무제](https://github.com/user-attachments/assets/0c2afd8c-e756-4564-aba4-214c9c3ee306) |
