### PR TITLE
[FIX] 댓글 조작 접근시 사용자 정보 확인

### DIFF
--- a/components/comment-list-element.js
+++ b/components/comment-list-element.js
@@ -13,6 +13,7 @@ class CommentListElement extends HTMLElement {
     this.postId = null
     this.storedData = JSON.parse(localStorage.getItem('user'))
     this.isEditing = false
+    this.isLogin = JSON.parse(localStorage.getItem('isLogin')) || false
   }
 
   async connectedCallback() {
@@ -101,8 +102,9 @@ class CommentListElement extends HTMLElement {
       button.addEventListener('click', () => {
         if (
           !this.isLogin ||
-          this.storedData.nickname !== this.post.post_writer
+          this.storedData.nickname !== comments[index].writer
         ) {
+          //alert(comments[index].writer)
           alert('게시글 작성자만 이용할 수 있는 기능입니다.')
           return
         } else {
@@ -119,7 +121,7 @@ class CommentListElement extends HTMLElement {
       button.addEventListener('click', () => {
         if (
           !this.isLogin ||
-          this.storedData.nickname !== this.post.post_writer
+          this.storedData.nickname !== comments[index].writer
         ) {
           alert('게시글 작성자만 이용할 수 있는 기능입니다.')
           return

--- a/components/comment-list-element.js
+++ b/components/comment-list-element.js
@@ -98,9 +98,17 @@ class CommentListElement extends HTMLElement {
     const updateButtons = this.shadowRoot.querySelectorAll('#button-update')
 
     updateButtons.forEach((button, index) => {
-      button.addEventListener('click', () =>
-        this.handleUpdate(comments[index].id, comments[index].content),
-      )
+      button.addEventListener('click', () => {
+        if (
+          !this.isLogin ||
+          this.storedData.nickname !== this.post.post_writer
+        ) {
+          alert('게시글 작성자만 이용할 수 있는 기능입니다.')
+          return
+        } else {
+          this.handleUpdate(comments[index].id, comments[index].content)
+        }
+      })
     })
   }
 
@@ -108,7 +116,17 @@ class CommentListElement extends HTMLElement {
     const deleteButtons = this.shadowRoot.querySelectorAll('#button-delete')
 
     deleteButtons.forEach((button, index) => {
-      button.addEventListener('click', () => this.openModal(comments[index].id))
+      button.addEventListener('click', () => {
+        if (
+          !this.isLogin ||
+          this.storedData.nickname !== this.post.post_writer
+        ) {
+          alert('게시글 작성자만 이용할 수 있는 기능입니다.')
+          return
+        } else {
+          this.openModal(comments[index].id)
+        }
+      })
     })
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #42 

## 📝작업 내용

> 로그인 상태에 따라 댓글 수정, 삭제에 대한 접근을 제한합니다.

### 스크린샷

> | 로그인 하지 않은 경우 | 로그인 하였으나 인가되지 않은 경우 | 인가된 접근의 경우 |
> | -- | -- | -- |
> | ![무제](https://github.com/user-attachments/assets/55bdccb2-0ee6-4c82-99e4-5192204f46f1) | ![무제](https://github.com/user-attachments/assets/d5a88776-f819-478f-ba46-6cde54bb468a) | ![무제](https://github.com/user-attachments/assets/e83f82ed-97f8-4361-9335-e41d80e6bd32) |
